### PR TITLE
[bugfix] the "nlp_factory.h" is now included only once

### DIFF
--- a/towr_core/include/towr/towr.h
+++ b/towr_core/include/towr/towr.h
@@ -42,7 +42,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "height_map.h"
 #include "nlp_factory.h"
 #include "parameters.h"
-#include "nlp_factory.h"
 
 
 namespace towr {


### PR DESCRIPTION
The
 `nlp_factory.h` 
was included twice. I removed the second include.