### PR TITLE
Changed CMakeLists to install header files

### DIFF
--- a/towr_ros/CMakeLists.txt
+++ b/towr_ros/CMakeLists.txt
@@ -19,7 +19,9 @@ find_package(catkin REQUIRED COMPONENTS
 add_message_files( FILES TowrCommand.msg )
 generate_messages( DEPENDENCIES std_msgs xpp_msgs )
 
-catkin_package()
+catkin_package(
+   INCLUDE_DIRS include
+)
 
 
 ###########
@@ -112,6 +114,12 @@ install(
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+# Mark header files for installation
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  PATTERN ".svn" EXCLUDE
 )
 
 # Mark other files for installation


### PR DESCRIPTION
Allows to include header files of "towr_ros" in dependent packages