### PR TITLE
Access to optimization parameters

### DIFF
--- a/towr/include/towr/initialization/gait_generator.h
+++ b/towr/include/towr/initialization/gait_generator.h
@@ -52,7 +52,15 @@ public:
   using GaitInfo      = std::pair<VecTimes,std::vector<ContactState>>;
   using EE            = uint;
 
+  /**
+   * @brief Predefined full steps sequences.
+   */
   enum Combos { C0, C1, C2, C3, C4, COMBO_COUNT};
+
+  /**
+   * @brief Predefined full steps.
+   * Each value encodes specific gait diagram for one full step.
+   */
   enum Gaits  {Stand=0, Flight,
                Walk1, Walk2, Walk2E,
                Run2, Run2E, Run1, Run1E, Run3, Run3E,
@@ -85,6 +93,12 @@ public:
    */
   virtual void SetCombo(Combos combo) = 0;
 
+  /**
+   * @brief  Sets the times_ and contacts_ variables according to the gaits.
+   * @param gaits The sequence of steps which defines gait. For example use @c {Stand,Walk1,Walk1,Stand} to declare walking gait with two steps.
+   */
+  void SetGaits(const std::vector<Gaits>& gaits);
+
 protected:
   /// Phase times for the complete robot during which no contact state changes.
   std::vector<double> times_;
@@ -94,9 +108,6 @@ protected:
    * be equal to the above times_.
    */
   std::vector<ContactState> contacts_;
-
-  /// Sets the times_ and contacts_ variables according to the gaits.
-  void SetGaits(const std::vector<Gaits>& gaits);
 
   /**
    * Removes the last phase that would transition to a new stride.

--- a/towr/include/towr/initialization/gait_generator.h
+++ b/towr/include/towr/initialization/gait_generator.h
@@ -73,7 +73,13 @@ public:
   virtual ~GaitGenerator () = default;
 
   /**
-   * @returns the swing and stance durations for the set gait.
+   * @returns the swing and stance durations for the set gait without scaling.
+   * @param ee  endeffector for which the phase durations are desired.
+   */
+  VecTimes GetUnscaledPhaseDurations(EE ee) const;
+
+  /**
+   * @returns the swing and stance durations for the set gait scaled to given time.
    * @param ee  endeffector for which the phase durations are desired.
    * @param T   total time for all phases, durations are scaled by that.
    */

--- a/towr/include/towr/initialization/gait_generator.h
+++ b/towr/include/towr/initialization/gait_generator.h
@@ -73,6 +73,14 @@ public:
   virtual ~GaitGenerator () = default;
 
   /**
+   * @brief return unscaled total duration of step sequence
+   * Usually unscaled duration of each @ref Gaits element equal to one. So
+   * this number can be used to scale constraints checks.
+   * @return total unscaled duration of step sequence
+   **/
+  double GetUnscaledTotalDuration() const;
+
+  /**
    * @returns the swing and stance durations for the set gait without scaling.
    * @param ee  endeffector for which the phase durations are desired.
    */

--- a/towr/include/towr/initialization/gait_generator.h
+++ b/towr/include/towr/initialization/gait_generator.h
@@ -130,7 +130,6 @@ protected:
   GaitInfo RemoveTransition(const GaitInfo& g) const;
 
 private:
-  FootDurations GetPhaseDurations() const;
   virtual GaitInfo GetGait(Gaits gait) const = 0;
 };
 

--- a/towr/include/towr/initialization/gait_generator.h
+++ b/towr/include/towr/initialization/gait_generator.h
@@ -118,7 +118,6 @@ protected:
 private:
   FootDurations GetPhaseDurations() const;
   virtual GaitInfo GetGait(Gaits gait) const = 0;
-  VecTimes GetNormalizedPhaseDurations(EE ee) const;
 };
 
 } /* namespace towr */

--- a/towr/include/towr/parameters.h
+++ b/towr/include/towr/parameters.h
@@ -191,6 +191,57 @@ struct Parameters {
    */
   void PenalizeEndeffectorForces();
 
+public:
+
+  /**
+   * @brief  Interval at which the dynamic constraint is enforced.
+   */
+  double dt_constraint_dynamic_;
+
+  /**
+   * @brief  Interval at which the range of motion constraint is enforced.
+   */
+  double dt_constraint_range_of_motion_;
+
+  /**
+   * @brief  Interval at which the base motion constraint is enforced.
+   */
+  double dt_constraint_base_motion_;
+
+  /**
+   * @brief  Fixed duration of each cubic polynomial describing the base motion.
+   */
+  double duration_base_polynomial_;
+
+  /** Minimum and maximum time for each phase (swing,stance).
+   *  Only used when optimizing over phase durations
+   */
+  std::array<double,2> bound_phase_duration_ = {{0.0, 1e10}};
+
+  /**
+   * @brief  Number of polynomials to parameterize foot movement during swing phases.
+   */
+  int ee_polynomials_per_swing_phase_;
+
+  /**
+   * @brief  Number of polynomials to parameterize each contact force during stance phase.
+   */
+  int force_polynomials_per_stance_phase_;
+
+  /**
+   * @brief  The maximum allowable force [N] in normal direction
+   */
+  double force_limit_in_normal_direction_;
+
+  /**
+   * @brief  which dimensions (x,y,z) of the final base state should be bounded
+   * Use @ref Dim3D enum to select desired dimentions.
+   */
+  std::vector<int> bounds_final_lin_pos_,
+                   bounds_final_lin_vel_,
+                   bounds_final_ang_pos_,
+                   bounds_final_ang_vel_;
+
 private:
   /// Which constraints should be used in the optimization problem.
   UsedConstraints constraints_;
@@ -216,32 +267,6 @@ private:
   /// Bounds for the phase durations.
   std::array<double,2> GetPhaseDurationBounds() const;
 
-  /// Interval at which the dynamic constraint is enforced.
-  double dt_constraint_dynamic_;
-
-  /// Interval at which the range of motion constraint is enforced.
-  double dt_constraint_range_of_motion_;
-
-  /// Interval at which the base motion constraint is enforced.
-  double dt_constraint_base_motion_;
-
-  /// Fixed duration of each cubic polynomial describing the base motion.
-  double duration_base_polynomial_;
-
-  /** Minimum and maximum time for each phase (swing,stance).
-   *  Only used when optimizing over phase durations
-   */
-  std::array<double,2> bound_phase_duration_ = {{0.0, 1e10}};
-
-  /// Number of polynomials to parameterize foot movement during swing phases.
-  int ee_polynomials_per_swing_phase_;
-
-  /// Number of polynomials to parameterize each contact force during stance phase.
-  int force_polynomials_per_stance_phase_;
-
-  /// The maximum allowable force [N] in normal direction
-  double force_limit_in_normal_direction_;
-
   /**
    * @brief Ensures that the dynamic model is fullfilled at discrete times.
    */
@@ -257,11 +282,6 @@ private:
    */
   void SetForceConstraint();
 
-  /// which dimensions (x,y,z) of the final base state should be bounded
-  std::vector<int> bounds_final_lin_pos_,
-                   bounds_final_lin_vel_,
-                   bounds_final_ang_pos_,
-                   bounds_final_ang_vel_;
 };
 
 } // namespace towr

--- a/towr/include/towr/parameters.h
+++ b/towr/include/towr/parameters.h
@@ -211,7 +211,7 @@ struct Parameters {
    *  if phase durations too short, can also cause kinematic constraint to
    *  be violated, so @ref dt_constraint_range_of_motion must be decreased.
    */
-  std::array<double,2> bound_phase_duration_ = {{0.0, 1e10}};
+  std::pair<double,double> bound_phase_duration_ = {0.0, 1e10};
 
   /**
    * @brief  Number of polynomials to parameterize foot movement during swing phases.
@@ -277,7 +277,7 @@ private:
   double GetTotalTime() const;
 
   /// Bounds for the phase durations.
-  std::array<double,2> GetPhaseDurationBounds() const;
+  std::pair<double,double> GetPhaseDurationBounds() const;
 
 };
 

--- a/towr/include/towr/parameters.h
+++ b/towr/include/towr/parameters.h
@@ -261,7 +261,6 @@ public:
   void PenalizeEndeffectorForces();
 
 private:
-
   /// The durations of each base polynomial in the spline (lin+ang).
   VecTimes GetBasePolyDurations() const;
 
@@ -279,7 +278,6 @@ private:
 
   /// Bounds for the phase durations.
   std::pair<double,double> GetPhaseDurationBounds() const;
-
 };
 
 } // namespace towr

--- a/towr/include/towr/parameters.h
+++ b/towr/include/towr/parameters.h
@@ -258,10 +258,10 @@ private:
   void SetForceConstraint();
 
   /// which dimensions (x,y,z) of the final base state should be bounded
-  std::vector<int> bounds_final_lin_pos,
-                   bounds_final_lin_vel,
-                   bounds_final_ang_pos,
-                   bounds_final_ang_vel;
+  std::vector<int> bounds_final_lin_pos_,
+                   bounds_final_lin_vel_,
+                   bounds_final_ang_pos_,
+                   bounds_final_ang_vel_;
 };
 
 } // namespace towr

--- a/towr/include/towr/parameters.h
+++ b/towr/include/towr/parameters.h
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <vector>
 #include <array>
+#include <towr/variables/cartesian_dimensions.h>
 
 namespace towr {
 
@@ -186,56 +187,56 @@ struct Parameters {
   CostWeights costs_;
 
   /**
-   * @brief  Interval at which the dynamic constraint is enforced.
+   * @brief  Interval [s] at which the dynamic constraint is enforced. 
    */
-  double dt_constraint_dynamic_;
+  double dt_constraint_dynamic_ = 0.1;
 
   /**
-   * @brief  Interval at which the range of motion constraint is enforced.
+   * @brief  Interval [s] at which the range of motion constraint is enforced. 
    */
-  double dt_constraint_range_of_motion_;
+  double dt_constraint_range_of_motion_ = 0.08;
 
   /**
-   * @brief  Interval at which the base motion constraint is enforced.
+   * @brief  Interval [s] at which the base motion constraint is enforced.
    */
-  double dt_constraint_base_motion_;
+  double dt_constraint_base_motion_ = 0.1/4.0;
 
   /**
-   * @brief  Fixed duration of each cubic polynomial describing the base motion.
+   * @brief  Fixed duration [s] of each cubic polynomial describing the base motion.
    */
-  double duration_base_polynomial_;
+  double duration_base_polynomial_ = 0.1;
 
-  /** Minimum and maximum time for each phase (swing,stance).
+  /** Minimum and maximum time [s] for each phase (swing,stance).
    *  Only used when optimizing over phase durations
    *  Limiting phase durations can help convergence when optimizing gait
    *  if phase durations too short, can also cause kinematic constraint to
    *  be violated, so @ref dt_constraint_range_of_motion must be decreased.
    */
-  std::pair<double,double> bound_phase_duration_ = {0.0, 1e10};
+  std::pair<double,double> bound_phase_duration_ = {0.2, 1.0};
 
   /**
    * @brief  Number of polynomials to parameterize foot movement during swing phases.
    */
-  int ee_polynomials_per_swing_phase_;
+  int ee_polynomials_per_swing_phase_ = 2; // so step can at least lift leg
 
   /**
    * @brief  Number of polynomials to parameterize each contact force during stance phase.
    */
-  int force_polynomials_per_stance_phase_;
+  int force_polynomials_per_stance_phase_ = 3;
 
   /**
    * @brief  The maximum allowable force [N] in normal direction
    */
-  double force_limit_in_normal_direction_;
+  double force_limit_in_normal_direction_ = 1000;
 
   /**
    * @brief  which dimensions (x,y,z) of the final base state should be bounded
    * Use @ref Dim3D enum to select desired dimentions.
    */
-  std::vector<int> bounds_final_lin_pos_,
-                   bounds_final_lin_vel_,
-                   bounds_final_ang_pos_,
-                   bounds_final_ang_vel_;
+  std::vector<int> bounds_final_lin_pos_ = { X,Y };
+  std::vector<int> bounds_final_lin_vel_ = { X,Y,Z };
+  std::vector<int> bounds_final_ang_pos_ = { X,Y,Z };
+  std::vector<int> bounds_final_ang_vel_ = { X,Y,Z };
 
 public:
   /**

--- a/towr/src/gait_generator.cc
+++ b/towr/src/gait_generator.cc
@@ -52,7 +52,7 @@ GaitGenerator::MakeGaitGenerator(int leg_count)
 }
 
 GaitGenerator::VecTimes
-GaitGenerator::GetPhaseDurations (double new_t_total, EE ee) const
+GaitGenerator::GetUnscaledPhaseDurations (EE ee) const
 {
   double d_accumulated = 0.0;
 
@@ -68,6 +68,14 @@ GaitGenerator::GetPhaseDurations (double new_t_total, EE ee) const
   }
   // push back last phase
   durations.push_back(d_accumulated + times_.back());
+
+  return durations;
+}
+
+GaitGenerator::VecTimes
+GaitGenerator::GetPhaseDurations (double new_t_total, EE ee) const
+{
+  std::vector<double> durations = GetUnscaledPhaseDurations(ee);
   // calculate total time 
   double old_t_total = std::accumulate(durations.begin(), durations.end(), 0.0);
   // scale to new total time

--- a/towr/src/gait_generator.cc
+++ b/towr/src/gait_generator.cc
@@ -51,6 +51,12 @@ GaitGenerator::MakeGaitGenerator(int leg_count)
   }
 }
 
+double
+GaitGenerator::GetUnscaledTotalDuration () const
+{
+  return std::accumulate(times_.begin(), times_.end(), 0.0);
+}
+
 GaitGenerator::VecTimes
 GaitGenerator::GetUnscaledPhaseDurations (EE ee) const
 {

--- a/towr/src/gait_generator.cc
+++ b/towr/src/gait_generator.cc
@@ -91,37 +91,6 @@ GaitGenerator::GetPhaseDurations (double new_t_total, EE ee) const
   return durations;
 }
 
-GaitGenerator::FootDurations
-GaitGenerator::GetPhaseDurations () const
-{
-  int n_ee = contacts_.front().size();
-  VecTimes d_accumulated(n_ee, 0.0);
-
-  FootDurations foot_durations(n_ee);
-  for (int phase=0; phase<contacts_.size()-1; ++phase) {
-    ContactState curr = contacts_.at(phase);
-    ContactState next = contacts_.at(phase+1);
-
-    for (int ee=0; ee<curr.size(); ++ee) {
-      d_accumulated.at(ee) += times_.at(phase);
-
-      // if contact will change in next phase, so this phase duration complete
-      bool contacts_will_change = curr.at(ee) != next.at(ee);
-      if (contacts_will_change)  {
-        foot_durations.at(ee).push_back(d_accumulated.at(ee));
-        d_accumulated.at(ee) = 0.0;
-      }
-    }
-  }
-
-  // push back last phase
-  for (int ee=0; ee<contacts_.back().size(); ++ee)
-    foot_durations.at(ee).push_back(d_accumulated.at(ee) + times_.back());
-
-
-  return foot_durations;
-}
-
 bool
 GaitGenerator::IsInContactAtStart (EE ee) const
 {

--- a/towr/src/gait_generator.cc
+++ b/towr/src/gait_generator.cc
@@ -75,7 +75,6 @@ GaitGenerator::GetPhaseDurations (double new_t_total, EE ee) const
                  [new_t_total, old_t_total](double t){ return t / old_t_total * new_t_total; });
 
   return durations;
-
 }
 
 GaitGenerator::FootDurations

--- a/towr/src/nlp_formulation.cc
+++ b/towr/src/nlp_formulation.cc
@@ -189,8 +189,8 @@ NlpFormulation::MakeContactScheduleVariables () const
     auto var = std::make_shared<PhaseDurations>(ee,
                                                 params_.ee_phase_durations_.at(ee),
                                                 params_.ee_in_contact_at_start_.at(ee),
-                                                params_.GetPhaseDurationBounds().front(),
-                                                params_.GetPhaseDurationBounds().back());
+                                                params_.GetPhaseDurationBounds().first,
+                                                params_.GetPhaseDurationBounds().second);
     vars.push_back(var);
   }
 

--- a/towr/src/nlp_formulation.cc
+++ b/towr/src/nlp_formulation.cc
@@ -109,16 +109,16 @@ NlpFormulation::MakeBaseVariables () const
   spline_lin->SetByLinearInterpolation(initial_base_.lin.p(), final_pos, params_.GetTotalTime());
   spline_lin->AddStartBound(kPos, {X,Y,Z}, initial_base_.lin.p());
   spline_lin->AddStartBound(kVel, {X,Y,Z}, initial_base_.lin.v());
-  spline_lin->AddFinalBound(kPos, params_.bounds_final_lin_pos,   final_base_.lin.p());
-  spline_lin->AddFinalBound(kVel, params_.bounds_final_lin_vel, final_base_.lin.v());
+  spline_lin->AddFinalBound(kPos, params_.bounds_final_lin_pos_,   final_base_.lin.p());
+  spline_lin->AddFinalBound(kVel, params_.bounds_final_lin_vel_, final_base_.lin.v());
   vars.push_back(spline_lin);
 
   auto spline_ang = std::make_shared<NodesVariablesAll>(n_nodes, k3D, id::base_ang_nodes);
   spline_ang->SetByLinearInterpolation(initial_base_.ang.p(), final_base_.ang.p(), params_.GetTotalTime());
   spline_ang->AddStartBound(kPos, {X,Y,Z}, initial_base_.ang.p());
   spline_ang->AddStartBound(kVel, {X,Y,Z}, initial_base_.ang.v());
-  spline_ang->AddFinalBound(kPos, params_.bounds_final_ang_pos, final_base_.ang.p());
-  spline_ang->AddFinalBound(kVel, params_.bounds_final_ang_vel, final_base_.ang.v());
+  spline_ang->AddFinalBound(kPos, params_.bounds_final_ang_pos_, final_base_.ang.p());
+  spline_ang->AddFinalBound(kVel, params_.bounds_final_ang_vel_, final_base_.ang.v());
   vars.push_back(spline_ang);
 
   return vars;

--- a/towr/src/parameters.cc
+++ b/towr/src/parameters.cc
@@ -28,7 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ******************************************************************************/
 
 #include <towr/parameters.h>
-#include <towr/variables/cartesian_dimensions.h>
 
 #include <algorithm>
 #include <numeric>      // std::accumulate
@@ -39,21 +38,6 @@ namespace towr {
 
 Parameters::Parameters ()
 {
-  // default optimization parameteres
-  duration_base_polynomial_ = 0.1; // [s]
-  dt_constraint_dynamic_ = 0.1; // [s]
-  dt_constraint_range_of_motion_ = 0.08; // [s]
-  dt_constraint_base_motion_ = duration_base_polynomial_/4.0;
-  bound_phase_duration_.first = 0.2;
-  bound_phase_duration_.second  = 1.0;
-  ee_polynomials_per_swing_phase_ = 2; // so step can at least lift leg
-  force_polynomials_per_stance_phase_ = 3;
-  force_limit_in_normal_direction_ = 1000;
-  bounds_final_lin_pos_ = {X,Y};
-  bounds_final_lin_vel_ = {X,Y,Z};
-  bounds_final_ang_pos_ = {X,Y,Z};
-  bounds_final_ang_vel_ = {X,Y,Z};
-
   // these are the basic constraints that always have to be set
   constraints_.push_back(Terrain);
   // dynamic constraints

--- a/towr/src/parameters.cc
+++ b/towr/src/parameters.cc
@@ -44,8 +44,8 @@ Parameters::Parameters ()
   dt_constraint_dynamic_ = 0.1; // [s]
   dt_constraint_range_of_motion_ = 0.08; // [s]
   dt_constraint_base_motion_ = duration_base_polynomial_/4.0;
-  bound_phase_duration_.front() = 0.2;
-  bound_phase_duration_.back()  = 1.0;
+  bound_phase_duration_.first = 0.2;
+  bound_phase_duration_.second  = 1.0;
   ee_polynomials_per_swing_phase_ = 2; // so step can at least lift leg
   force_polynomials_per_stance_phase_ = 3;
   force_limit_in_normal_direction_ = 1000;
@@ -148,13 +148,13 @@ Parameters::IsOptimizeTimings () const
   return std::find(v.begin(), v.end(), c) != v.end();
 }
 
-std::array<double,2>
+std::pair<double,double>
 Parameters::GetPhaseDurationBounds () const
 {
   // adjust bound to always be less than total duration of trajectory
-  double upper_bound = bound_phase_duration_.back();
-  double max = GetTotalTime()>upper_bound? upper_bound : GetTotalTime();
-  return {bound_phase_duration_.front(), max};
+  double upper_bound = bound_phase_duration_.second;
+  double max = GetTotalTime()>upper_bound ? upper_bound : GetTotalTime();
+  return {bound_phase_duration_.first, max};
 }
 
 } // namespace towr

--- a/towr/src/parameters.cc
+++ b/towr/src/parameters.cc
@@ -39,10 +39,20 @@ namespace towr {
 
 Parameters::Parameters ()
 {
-  // constructs optimization variables
+  // default optimization parameteres
   duration_base_polynomial_ = 0.1; // [s]
-  force_polynomials_per_stance_phase_ = 3;
+  dt_constraint_dynamic_ = 0.1; // [s]
+  dt_constraint_range_of_motion_ = 0.08; // [s]
+  dt_constraint_base_motion_ = duration_base_polynomial_/4.0;
+  bound_phase_duration_.front() = 0.2;
+  bound_phase_duration_.back()  = 1.0;
   ee_polynomials_per_swing_phase_ = 2; // so step can at least lift leg
+  force_polynomials_per_stance_phase_ = 3;
+  force_limit_in_normal_direction_ = 1000;
+  bounds_final_lin_pos_ = {X,Y};
+  bounds_final_lin_vel_ = {X,Y,Z};
+  bounds_final_ang_pos_ = {X,Y,Z};
+  bounds_final_ang_vel_ = {X,Y,Z};
 
   // these are the basic constraints that always have to be set
   constraints_.push_back(Terrain);
@@ -50,10 +60,6 @@ Parameters::Parameters ()
   SetKinematicConstraint();
   SetForceConstraint();
 
-  bounds_final_lin_pos_ = {X,Y};
-  bounds_final_lin_vel_ = {X,Y,Z};
-  bounds_final_ang_pos_ = {X,Y,Z};
-  bounds_final_ang_vel_ = {X,Y,Z};
   // additional restrictions are set directly on the variables in nlp_factory,
   // such as e.g. initial and endeffector,...
 }
@@ -61,7 +67,6 @@ Parameters::Parameters ()
 void
 Parameters::SetDynamicConstraint ()
 {
-  dt_constraint_dynamic_ = 0.1;
   constraints_.push_back(Dynamic);
   constraints_.push_back(BaseAcc); // so accelerations don't jump between polynomials
 }
@@ -69,14 +74,12 @@ Parameters::SetDynamicConstraint ()
 void
 Parameters::SetKinematicConstraint ()
 {
-  dt_constraint_range_of_motion_ = 0.08;
   constraints_.push_back(EndeffectorRom);
 }
 
 void
 Parameters::SetForceConstraint()
 {
-  force_limit_in_normal_direction_ = 1000;
   constraints_.push_back(Force);
 }
 
@@ -89,18 +92,12 @@ Parameters::SetSwingConstraint()
 void
 Parameters::OptimizePhaseDurations ()
 {
-  // limiting this range can help convergence when optimizing gait
-  // if phase durations too short, can also cause kinematic constraint to
-  // be violated, so dt_constraint_range_of_motion must be decreased.
-  bound_phase_duration_.front() = 0.2;
-  bound_phase_duration_.back()  = 1.0;
   constraints_.push_back(TotalTime);
 }
 
 void
 Parameters::RestrictBaseRangeOfMotion ()
 {
-  dt_constraint_base_motion_ = duration_base_polynomial_/4.;
   constraints_.push_back(BaseRom);
 }
 

--- a/towr/src/parameters.cc
+++ b/towr/src/parameters.cc
@@ -56,31 +56,16 @@ Parameters::Parameters ()
 
   // these are the basic constraints that always have to be set
   constraints_.push_back(Terrain);
-  SetDynamicConstraint();
-  SetKinematicConstraint();
-  SetForceConstraint();
+  // dynamic constraints
+  constraints_.push_back(Dynamic);
+  constraints_.push_back(BaseAcc); 
+  // robot kinematics
+  constraints_.push_back(EndeffectorRom);
+  // force cones
+  constraints_.push_back(Force);
 
   // additional restrictions are set directly on the variables in nlp_factory,
   // such as e.g. initial and endeffector,...
-}
-
-void
-Parameters::SetDynamicConstraint ()
-{
-  constraints_.push_back(Dynamic);
-  constraints_.push_back(BaseAcc); // so accelerations don't jump between polynomials
-}
-
-void
-Parameters::SetKinematicConstraint ()
-{
-  constraints_.push_back(EndeffectorRom);
-}
-
-void
-Parameters::SetForceConstraint()
-{
-  constraints_.push_back(Force);
 }
 
 void

--- a/towr/src/parameters.cc
+++ b/towr/src/parameters.cc
@@ -50,10 +50,10 @@ Parameters::Parameters ()
   SetKinematicConstraint();
   SetForceConstraint();
 
-  bounds_final_lin_pos = {X,Y};
-  bounds_final_lin_vel = {X,Y,Z};
-  bounds_final_ang_pos = {X,Y,Z};
-  bounds_final_ang_vel = {X,Y,Z};
+  bounds_final_lin_pos_ = {X,Y};
+  bounds_final_lin_vel_ = {X,Y,Z};
+  bounds_final_ang_pos_ = {X,Y,Z};
+  bounds_final_ang_vel_ = {X,Y,Z};
   // additional restrictions are set directly on the variables in nlp_factory,
   // such as e.g. initial and endeffector,...
 }


### PR DESCRIPTION
This pull request addresses issue  #54. 
1. Fields of `Parameters` class is made public. Unnecessary access methods are removed.
2. `GaitGenerator::SetGaits()` is made public.
3. A few cosmetic changes: `std::pair` to represent bounds instead of `array<2>`, optimized GetPhase Durations().