### PR TITLE
[TotalDurationConstraint::GetBounds] change variable type definition

### DIFF
--- a/towr/src/total_duration_constraint.cc
+++ b/towr/src/total_duration_constraint.cc
@@ -59,7 +59,7 @@ TotalDurationConstraint::GetBounds () const
 {
   // TODO hacky and should be fixed
   // since last phase is not optimized over these hardcoded numbers go here
-  int min_duration_last_phase = 0.2;
+  double min_duration_last_phase = 0.2;
   return VecBound(GetRows(), ifopt::Bounds(0.1, T_total_-min_duration_last_phase));
 }
 


### PR DESCRIPTION
The variable min_duration_last_phase is defined as an Int but it should be a Double.