### PR TITLE
Fix outer derivative by replacing cwiseproduct with explicit matvec.

### DIFF
--- a/towr/src/height_map.cc
+++ b/towr/src/height_map.cc
@@ -86,8 +86,12 @@ HeightMap::GetDerivativeOfNormalizedBasisWrt (Direction basis, Dim2D dim,
 
   // outer derivative
   Vector3d v = GetBasis(basis, x,y, {});
-  Vector3d dn_norm_wrt_n = GetDerivativeOfNormalizedVectorWrtNonNormalizedIndex(v, dim);
-  return dn_norm_wrt_n.cwiseProduct(dv_wrt_dim);
+  Vector3d result = Vector3d::Zero();
+  for (auto inner_dim : {X,Y,Z}) {
+    auto dn_norm_wrt_n = GetDerivativeOfNormalizedVectorWrtNonNormalizedIndex(v, inner_dim);
+    result = result + dv_wrt_dim(inner_dim) * dn_norm_wrt_n;
+  }
+  return result;
 }
 
 HeightMap::Vector3d


### PR DESCRIPTION
Thanks for writing such a nice piece of software!

There seems to be a mistake in how the derivative of the normal/tangent is computed with respect to the x or y directions. The derivative of the normalized vector (n_norm) wrt the non-normalized one (n) is a 3 x 3 matrix that should be fully multiplied with the vector (dn_x/dx, dn_y/dx, dn_z/dx) while currently only a single column is multiplied elementwise. This is only an issue for terrains with non-zero second-order derivatives. Changing these lines resulted in fewer incorrect gradient values according to IPOpt's gradient checker for me.